### PR TITLE
Increase max vector bytes size from 65K -> 512K

### DIFF
--- a/asm/src/main/java/org/objectweb/asm/ByteVector.java
+++ b/asm/src/main/java/org/objectweb/asm/ByteVector.java
@@ -41,6 +41,8 @@ public class ByteVector {
   /** The actual number of bytes in this vector. */
   int length;
 
+  public static final int BYTE_VECTOR_MAX_SIZE = 512000;
+
   /** Constructs a new {@link ByteVector} with a default initial capacity. */
   public ByteVector() {
     data = new byte[64];
@@ -236,12 +238,12 @@ public class ByteVector {
    * Puts an UTF8 string into this byte vector. The byte vector is automatically enlarged if
    * necessary.
    *
-   * @param stringValue a String whose UTF8 encoded length must be less than 65536.
+   * @param stringValue a String whose UTF8 encoded length must be less than BYTE_VECTOR_MAX_SIZE.
    * @return this byte vector.
    */
   public ByteVector putUTF8(final String stringValue) {
     int charLength = stringValue.length();
-    if (charLength > 65535) {
+    if (charLength > BYTE_VECTOR_MAX_SIZE) {
       throw new IllegalArgumentException("UTF8 string too large");
     }
     int currentLength = length;
@@ -261,7 +263,7 @@ public class ByteVector {
         currentData[currentLength++] = (byte) charValue;
       } else {
         length = currentLength;
-        return encodeUTF8(stringValue, i, 65535);
+        return encodeUTF8(stringValue, i, BYTE_VECTOR_MAX_SIZE);
       }
     }
     length = currentLength;

--- a/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
+++ b/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
@@ -116,7 +116,7 @@ public class ByteVectorTest {
     byteVector.putUTF8("a\u0000\u0080\u0800");
     assertContains(byteVector, 0, 8, 'a', -64, -128, -62, -128, -32, -96, -128);
 
-    char[] charBuffer = new char[(ByteVector.BYTE_VECTOR_MAX_SIZE/2) + 1];
+    char[] charBuffer = new char[(BYTE_VECTOR_MAX_SIZE/2) + 1];
     Arrays.fill(charBuffer, '\u07FF');
     String test = new String(charBuffer);
     int size_test = test.length();

--- a/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
+++ b/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
@@ -30,12 +30,12 @@ package org.objectweb.asm;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.objectweb.asm.ByteVector.BYTE_VECTOR_MAX_SIZE;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import static org.objectweb.asm.ByteVector.BYTE_VECTOR_MAX_SIZE;
 
 /**
  * ByteVector tests.

--- a/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
+++ b/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import static org.objectweb.asm.ByteVector.BYTE_VECTOR_MAX_SIZE;
 
 /**
  * ByteVector tests.
@@ -105,7 +106,7 @@ public class ByteVectorTest {
     byteVector.putUTF8("abc");
     assertContains(byteVector, 0, 3, 'a', 'b', 'c');
 
-    char[] charBuffer = new char[65536];
+    char[] charBuffer = new char[BYTE_VECTOR_MAX_SIZE + 1];
     assertThrows(IllegalArgumentException.class, () -> byteVector.putUTF8(new String(charBuffer)));
   }
 
@@ -115,8 +116,10 @@ public class ByteVectorTest {
     byteVector.putUTF8("a\u0000\u0080\u0800");
     assertContains(byteVector, 0, 8, 'a', -64, -128, -62, -128, -32, -96, -128);
 
-    char[] charBuffer = new char[32768];
+    char[] charBuffer = new char[(ByteVector.BYTE_VECTOR_MAX_SIZE/2) + 1];
     Arrays.fill(charBuffer, '\u07FF');
+    String test = new String(charBuffer);
+    int size_test = test.length();
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class, () -> byteVector.putUTF8(new String(charBuffer)));
@@ -124,13 +127,13 @@ public class ByteVectorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {65535, 65536})
+  @ValueSource(ints = {BYTE_VECTOR_MAX_SIZE, BYTE_VECTOR_MAX_SIZE + 1})
   public void testPutUTF8_tooLong(int size) {
     ByteVector byteVector = new ByteVector(0);
     char[] charBuffer = new char[size];
     Arrays.fill(charBuffer, 'A');
     String utf8 = new String(charBuffer);
-    if (size > 65535) {
+    if (size > BYTE_VECTOR_MAX_SIZE) {
       IllegalArgumentException thrown =
           assertThrows(IllegalArgumentException.class, () -> byteVector.putUTF8(utf8));
       assertEquals("UTF8 string too large", thrown.getMessage());

--- a/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
+++ b/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java
@@ -116,7 +116,7 @@ public class ByteVectorTest {
     byteVector.putUTF8("a\u0000\u0080\u0800");
     assertContains(byteVector, 0, 8, 'a', -64, -128, -62, -128, -32, -96, -128);
 
-    char[] charBuffer = new char[(BYTE_VECTOR_MAX_SIZE/2) + 1];
+    char[] charBuffer = new char[(BYTE_VECTOR_MAX_SIZE / 2) + 1];
     Arrays.fill(charBuffer, '\u07FF');
     String test = new String(charBuffer);
     int size_test = test.length();


### PR DESCRIPTION
**Summary**: Bumping up the size of max vector bytes to allow for larger schemas. Tests on the [ByteVectorTest](https://github.com/shivtools/asm/blob/master/asm/src/test/java/org/objectweb/asm/ByteVectorTest.java) class pass. 

The master branch is forked from the [6.2.1 ASM branch](https://gitlab.ow2.org/asm/asm/tree/ASM_6_2_1).